### PR TITLE
Disable Name Resolution in Proxy Mode

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,8 @@
    [camel-snake-kebab "0.4.0"]
    [cheshire "5.9.0"]
    [com.cognitect/anomalies "0.1.12"]
-   [com.datomic/datomic-free "0.9.5697"]
+   [com.datomic/datomic-free "0.9.5697"
+    :exclusions [io.netty/netty-all]]
    [com.taoensso/timbre "4.10.0"]
    [info.cqframework/cql-to-elm "1.4.6"]
    [integrant "0.7.0"]

--- a/src/blaze/terminology_service/extern.clj
+++ b/src/blaze/terminology_service/extern.clj
@@ -66,8 +66,14 @@
                    client-middleware/wrap-url
                    client-middleware/wrap-query-params
                    client')))))}
+
+      ;; It's important to disable DNS resolving when in proxy mode, because
+      ;; first it's not necessary and second domain names which are resolvable
+      ;; by the proxy might not resolvable locally. Can be removed when
+      ;; https://github.com/ztellman/aleph/issues/522 is solved.
       (seq proxy-options)
-      (assoc-in [:connection-options :proxy-options] proxy-options))))
+      (update :connection-options assoc :proxy-options
+              proxy-options :name-resolver :noop))))
 
 
 (defn- expand-value-set [base opts params]


### PR DESCRIPTION
Also excluded netty-all from datomic-free in order to have only one set of Netty
JAr's in classpath.