### PR TITLE
Authentication

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,12 @@
      io.netty/netty-handler
      io.netty/netty-transport
      io.netty/netty-transport-native-epoll]]
+   [buddy/buddy-auth "2.2.0"
+    :exclusions
+    [com.google.guava/guava]
+    [com.google.errorprone/error_prone_annotations]
+    [com.google.code.findbugs/jsr305]]
+   [buddy/buddy-core "1.6.0"]
    [camel-snake-kebab "0.4.0"]
    [cheshire "5.9.0"]
    [com.cognitect/anomalies "0.1.12"]

--- a/src/blaze/middleware/authentication.clj
+++ b/src/blaze/middleware/authentication.clj
@@ -1,0 +1,58 @@
+(ns blaze.middleware.authentication
+  "Verifies a signed JWT using OpenID Connect to provide
+   the public key used to sign the token."
+  (:require
+    [buddy.auth.backends :as backends]
+    [buddy.auth.middleware :as middleware]
+    [buddy.core.keys :as keys]
+    [cheshire.core :as json]
+    [clojure.spec.alpha :as s])
+  (:import
+    (java.security PublicKey)))
+
+
+(s/fdef public-key
+  :args (s/cat :jwks-json string?)
+  :ret (s/nilable #(instance? PublicKey %)))
+
+
+(defn public-key [jwks-json]
+  "Take a the first jwk from jwks-json string and
+   convert it into a PublicKey."
+  (some-> jwks-json
+          (json/parse-string keyword)
+          :keys
+          first
+          keys/jwk->public-key))
+
+
+(s/fdef jwks-json
+  :args (s/cat :url string?)
+  :ret map?)
+
+
+(defn jwks-json [url]
+  (let [well-known "/.well-known/openid-configuration"
+        jwks-json  (some-> url
+                           (str well-known)
+                           slurp
+                           json/parse-string
+                           (get "jwks_uri")
+                           slurp)]
+    (if (some? jwks-json)
+      jwks-json
+       (throw (ex-info "No jwk found"
+                       {:cause (str "No jwk found at " url well-known)})))))
+
+
+(s/fdef wrap-authentication
+  :args (s/cat :public-key #(instance? PublicKey %)))
+
+
+(defn wrap-authentication [public-key]
+  (fn [handler]
+    (middleware/wrap-authentication
+     handler
+     (backends/jws {:token-name "Bearer"
+                    :secret     public-key
+                    :options    {:alg :rs256}}))))

--- a/src/blaze/middleware/guard.clj
+++ b/src/blaze/middleware/guard.clj
@@ -1,0 +1,14 @@
+(ns blaze.middleware.guard
+  (:require
+   [buddy.auth :refer [authenticated?]]
+   [ring.util.response :as ring]))
+
+
+(defn wrap-guard
+  "If the request is unauthenticated return a 401 response."
+  [handler]
+  (fn [request]
+    (if (authenticated? request)
+      (handler request)
+      (-> (ring/response {:message "Unauthenticated"})
+          (ring/status 401)))))

--- a/test/blaze/handler/app_test.clj
+++ b/test/blaze/handler/app_test.clj
@@ -17,7 +17,7 @@
     {:spec
      {`handler
       (s/fspec
-        :args (s/cat :handlers map?))}})
+        :args (s/cat :handlers map? :middleware map?))}})
   (log/with-merged-config {:level :fatal} (f))
   (st/unstrument))
 
@@ -31,8 +31,12 @@
    :handler.fhir/core (fn [_] ::fhir-core-handler)})
 
 
+(def ^:private middleware
+  {:middleware/authentication identity})
+
+
 (def ^:private test-handler
-  (reitit-ring/ring-handler (router handlers)))
+  (reitit-ring/ring-handler (router handlers middleware)))
 
 
 (defn- match [path request-method]
@@ -60,7 +64,7 @@
 
 (deftest exception-test
   (testing "Exceptions from handlers are converted to OperationOutcomes."
-    (given @((handler handlers-throwing)
+    (given @((handler handlers-throwing middleware)
              {:uri "/fhir"
               :request-method :get})
       :status := 500

--- a/test/blaze/handler/fhir/core_test.clj
+++ b/test/blaze/handler/fhir/core_test.clj
@@ -17,7 +17,7 @@
     {:spec
      {`handler
       (s/fspec
-        :args (s/cat :base-url #{::base-url} :conn #{::conn} :handlers map?))}})
+        :args (s/cat :base-url #{::base-url} :conn #{::conn} :handlers map? :middleware map?))}})
   (st/instrument
     [`wrap-type]
     {:spec
@@ -50,8 +50,12 @@
    (fn [_] ::fhir-operation-evaluate-measure-handler)})
 
 
+(def ^:private middleware
+  {:middleware/guard identity})
+
+
 (defn test-handler []
-  (reitit-ring/ring-handler (router ::base-url ::conn handlers)))
+  (reitit-ring/ring-handler (router ::base-url ::conn handlers middleware)))
 
 
 (defn- match [path request-method]
@@ -74,7 +78,7 @@
 
 
 (deftest router-match-by-name-test
-  (let [router (router ::base-url ::conn handlers)]
+  (let [router (router ::base-url ::conn handlers middleware)]
     (are [name params path]
       (= (reitit/match->path (reitit/match-by-name router name params)) path)
 

--- a/test/blaze/middleware/authentication_test.clj
+++ b/test/blaze/middleware/authentication_test.clj
@@ -1,0 +1,16 @@
+(ns blaze.middleware.authentication-test
+  (:require
+   [blaze.middleware.authentication :refer [public-key]]
+   [clojure.test :refer :all])
+  (:import
+   (java.security PublicKey)))
+
+
+;; The following json has been taken from https://samples.auth0.com/.well-known/jwks.json
+(def jwks-json "{\"keys\":[{\"alg\":\"RS256\",\"kty\":\"RSA\",\"use\":\"sig\",\"x5c\":[\"MIIDCzCCAfOgAwIBAgIJAJP6qydiMpsuMA0GCSqGSIb3DQEBBQUAMBwxGjAYBgNVBAMMEXNhbXBsZXMuYXV0aDAuY29tMB4XDTE0MDUyNjIyMDA1MFoXDTI4MDIwMjIyMDA1MFowHDEaMBgGA1UEAwwRc2FtcGxlcy5hdXRoMC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCkH4CFGSJ4s3mwCBzaGGwxa9Jxzfb1ia4nUumxbsuaB7PClZZgrNQiOR3MXVNV9W6F1D+wjT6oFHOo7TOkVI22I/ff3XZTE0F35UUHGWRtiQ4LdZxwOPTed2Lax3F2DEyl3Y0CguUKbq2sSghvHYcggM6aj3N53VBsnBh/kdrURDLx1RYqBIL6Fvkhb/V/v/u9UKhZM0CDQRef9FZ7R8q9ie9cnbDOj1dT9d64kiJIYtTraG0gOrs4LI+4KK0EZu5R7Uo053IK7kfNasWhDkl8yxNYkDxwfcIuAcDmLgLnAI4tfW5beJuw+/w75PO/EwzwsnvppXaAz7e3Wf8g1yWFAgMBAAGjUDBOMB0GA1UdDgQWBBTsmytFLNox+NUZdTNlCUL3hHrngTAfBgNVHSMEGDAWgBTsmytFLNox+NUZdTNlCUL3hHrngTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBQUAA4IBAQAodbRX/34LnWB70l8dpDF1neDoG29F0XdpE9ICWHeWB1gb/FvJ5UMy9/pnL0DI3mPwkTDDob+16Zc68o6dT6sH3vEUP1iRreJlFADEmJZjrH9P4Y7ttx3G2Uw2RU5uucXIqiyMDBrQo4vx4Lnghl+b/WYbZJgzLfZLgkOEjcznS0Yi5Wdz6MvaL3FehSfweHyrjmxz0e8elHq7VY8OqRA+4PmUBce9BgDCk9fZFjgj8l0m9Vc5pPKSY9LMmTyrYkeDr/KppqdXKOCHmv7AIGb6rMCtbkIL/CM7Bh9Hx78/UKAz87Sl9A1yXVNjKbZwOEW60ORIwJmd8Tv46gJF+/rV\"],\"n\":\"pB-AhRkieLN5sAgc2hhsMWvScc329YmuJ1LpsW7LmgezwpWWYKzUIjkdzF1TVfVuhdQ_sI0-qBRzqO0zpFSNtiP33912UxNBd-VFBxlkbYkOC3WccDj03ndi2sdxdgxMpd2NAoLlCm6trEoIbx2HIIDOmo9zed1QbJwYf5Ha1EQy8dUWKgSC-hb5IW_1f7_7vVCoWTNAg0EXn_RWe0fKvYnvXJ2wzo9XU_XeuJIiSGLU62htIDq7OCyPuCitBGbuUe1KNOdyCu5HzWrFoQ5JfMsTWJA8cH3CLgHA5i4C5wCOLX1uW3ibsPv8O-TzvxMM8LJ76aV2gM-3t1n_INclhQ\",\"e\":\"AQAB\",\"kid\":\"NkJCQzIyQzRBMEU4NjhGNUU4MzU4RkY0M0ZDQzkwOUQ0Q0VGNUMwQg\",\"x5t\":\"NkJCQzIyQzRBMEU4NjhGNUU4MzU4RkY0M0ZDQzkwOUQ0Q0VGNUMwQg\"}]}")
+
+
+(deftest public-key-test
+  (testing "Returns type PublicKey after parsing jwks-json string"
+    (let [k (public-key jwks-json)]
+      (is (= (instance? PublicKey k))))))


### PR DESCRIPTION
## Summary

To add authentication to Blaze, I created a middleware that will try to verify a Signed JWT when the environment variable `OPENID_PROVIDER_URL` is a non-empty string. If `OPENID_PROVIDER_URL` is nil or an empty string, the request will be handled normally.

This PR depends on an external OAuth2 provider to provide and sign the tokens. For example, [Keycloak](https://www.keycloak.org/).

## New Dependencies

- `[buddy/buddy-core "1.6.0"]` for preparing the public key used to verify the token
- `[buddy/buddy-auth "2.2.0"]` for the provided ring middleware

## Authentication functionality

To authenticate the clinical end-user (often, but not always, the patient), [FHIR specifies](http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html#scopes-for-requesting-identity-data) that [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html) is used.

- The url in the `OPENID_PROVIDER_URL` must be the  [OpenID Issuer url](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig) to which `/.well-known/openid-configuration` will be appended
- Following the `jwks_uri` property leads to a json wrapped set of keys
- At present, my implementation only looks at the first of these keys
- This key is stored in a Clojure atom and is updated every 60 minutes (currently hardcoded in the Integrant configs)
- The public key from the atom is used to verify the signature of the authorization header bearer token.

## Architecture within Blaze

### Summary of Changes

I modified `blaze.handler.app/handler` and `blaze.handler.app/router` to accept a collection `middleware` alongside the `handler` collection. This was necessary to pass in configuration data from Integrant.

I expect you will have some opinions about this decision.

### Details

- Specs and configs are added for `authorization` its child `url` in _system.clj_
- Most notably, a `:middleware` property has been added to the `:app-handler` map in [system.clj:198](https://github.com/Breezeemr/blaze/pull/1/files#diff-65f5856be49a96dfce50af7ac7522e33R198-R199)
  - This change is reflected in the `:app-handler` init function at [src/blaze/system.clj:394](https://github.com/Breezeemr/blaze/pull/1/files#diff-65f5856be49a96dfce50af7ac7522e33R394-R395)
  - This same change continues into [src/blaze/handler/app.clj](https://github.com/Breezeemr/blaze/pull/1/files#diff-637d480758abc997cb2ca7597d0caa6b) where all the changes are related to passing the list of middleware into the router. Previous middleware was not configured via Integrant so did not need to be passed in this way, I have not touched any related to other middleware.
  - Lastly, the test in [test/blaze/handler/app_test.clj:37](https://github.com/Breezeemr/blaze/compare/master...Breezeemr:auth?diff=split&expand=1#diff-600823e4ff2df4a145761a133ae4021aR37) must also be updated to account for this change

- Separately, there is an executor running in its own thread that uses `manifold.time/every` to update the OpenID Provider's public key at the given interval

## Questions

- Should other middleware (e.g. `blaze.middleware.json`) that does not depend on external configuration be migrated to the Integrant-oriented approach or left as is?
- Do you have any preferred naming conventions?
- Do you have any commit conventions? Squashing?
